### PR TITLE
Render in contexts other than the main query

### DIFF
--- a/src/CommentIQ/Subscriber/AutomatedElevatedCommentSubscriber.php
+++ b/src/CommentIQ/Subscriber/AutomatedElevatedCommentSubscriber.php
@@ -86,8 +86,8 @@ class CommentIQ_Subscriber_AutomatedElevatedCommentSubscriber implements Comment
      */
     public function insert_elevated_comment($content)
     {
-        if (!is_main_query()
-            || !is_singular($this->post_types)
+		
+        if (!is_singular($this->post_types)
             || has_shortcode($content, CommentIQ_Shortcode_ElevatedCommentShortcode::get_name())
         ) {
             return $content;


### PR DESCRIPTION
What is the motivation for rendering only in the main query? It prevents rendering for other purposes, such as a Postmatic email. Are there undesirable consequences of removing the is_main_query() condition?
